### PR TITLE
DMS-1015: jtbConnectプロキシのネットワークエラー処理を修正

### DIFF
--- a/backend/src/jtbConnect.controller.ts
+++ b/backend/src/jtbConnect.controller.ts
@@ -43,10 +43,10 @@ export class PmsJtbConnectController {
           throw new HttpException(e.response?.data, e.response?.status);
         }
         else if (e.request) {
-          this.logger.log(`error.request = ${e.request}`);
-          throw new HttpException(e.request, e.status);
+          this.logger.log(`error.message = ${e.message}`);
+          throw new HttpException(e.message, 504);
         }
-        throw new HttpException(e.message, e.status);
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -80,10 +80,10 @@ export class PmsJtbConnectController {
           throw new HttpException(e.response?.data, e.response?.status);
         }
         else if (e.request) {
-          this.logger.log(`error.request = ${e.request}`);
-          throw new HttpException(e.request, e.status);
+          this.logger.log(`error.message = ${e.message}`);
+          throw new HttpException(e.message, 504);
         }
-        throw new HttpException(e.message, e.status);
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -114,10 +114,10 @@ export class PmsJtbConnectController {
           throw new HttpException(e.response?.data, e.response?.status);
         }
         else if (e.request) {
-          this.logger.log(`error.request = ${e.request}`);
-          throw new HttpException(e.request, e.status);
+          this.logger.log(`error.message = ${e.message}`);
+          throw new HttpException(e.message, 504);
         }
-        throw new HttpException(e.message, e.status);
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -148,10 +148,10 @@ export class PmsJtbConnectController {
           throw new HttpException(e.response?.data, e.response?.status);
         }
         else if (e.request) {
-          this.logger.log(`error.request = ${e.request}`);
-          throw new HttpException(e.request, e.status);
+          this.logger.log(`error.message = ${e.message}`);
+          throw new HttpException(e.message, 504);
         }
-        throw new HttpException(e.message, e.status);
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }


### PR DESCRIPTION
## 概要
JTB DCH (dch.jtb.co.jp) への中継リクエストで応答がないネットワークエラー（`read ECONNRESET` 等）が発生した際、Cloud Functions プロキシ自体がクラッシュして原因不明の 500 "Internal Server Error" を返す問題を修正する。

## 背景
本番アラート `[production]PMS連携エラー`（claim2 / status=500）の調査で判明:

1. JTB側が応答を返さず `read ECONNRESET` が発生
2. `catchError` の `e.request` 分岐が、シリアライズ不能な生の `ClientRequest` オブジェクトと `undefined` ステータスで `HttpException` を throw
3. NestJS のレスポンスシリアライズで `TypeError: Converting circular structure to JSON` → 関数クラッシュ → GCF が汎用 500 を返却

## 変更内容
GET/POST/PUT/DELETE 4メソッドの `catchError` を修正:
- `e.request` 分岐: エラーメッセージ文字列 + **504** を返す（接続断として観測可能に）
- 最終フォールバック: `e.status ?? 500` で undefined ステータスを排除

## 検証
- `tsc --noEmit`（tsconfig.build.json）: エラーなし
- `npm run build:prod`（nest build、Cloud Buildと同一）: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)