### PR TITLE
DMS-1015: GCFランタイムをnodejs22へ更新

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -44,7 +44,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": "18"
+        "node": "22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "main": "dist/index.js",
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "scripts": {
     "prebuild": "rimraf dist",

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,13 +2,13 @@ timeout: 1800s
 steps:
 
   - id: 'Install: backend'
-    name: node:18
+    name: node:22
     dir: './backend'
     entrypoint: npm
     args: ['install']
 
   - id: 'Build: backend'
-    name: node:18
+    name: node:22
     dir: './backend'
     entrypoint: npm
     args: ['run', 'build:prod']
@@ -36,7 +36,7 @@ steps:
       - deploy
       - ${_FUNCTION_NAME}
       - --entry-point=api
-      - --runtime=nodejs18
+      - --runtime=nodejs22
       - --region=${_FUNCTION_REGION}
       - --source=.
       - --trigger-http


### PR DESCRIPTION
## 概要
PR #39 のステージングデプロイが以下のエラーで失敗したため、ランタイムを更新する。

```
ERROR: (gcloud.functions.deploy) argument --runtime: nodejs18 is not a supported runtime on GCF 1st gen.
```

Node.js 18 は GCF でサポート終了済み。`gcloud functions runtimes list` で確認したところ、1st gen で GA なのは nodejs22（nodejs20 は DEPRECATED）のため nodejs22 を採用。

## 変更内容
- `cloudbuild.yaml`: デプロイの `--runtime=nodejs18` → `nodejs22`、ビルドイメージ `node:18` → `node:22`
- `backend/package.json` / `package-lock.json`: engines `18` → `22`

## 検証
node:22 コンテナで Cloud Build と同一手順を再現し確認済み:
- `npm install` → `npm run build:prod`（nest build）: 成功
- ビルド成果物 `dist/app.module.js` の require ロード: 成功（依存関係が Node 22 で動作することを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)