### PR TITLE
DMS-1015: jtbConnectプロキシのネットワークエラー処理修正 + GCFランタイムnodejs22更新

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -44,7 +44,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": "18"
+        "node": "22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "main": "dist/index.js",
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "scripts": {
     "prebuild": "rimraf dist",

--- a/backend/src/jtbConnect.controller.ts
+++ b/backend/src/jtbConnect.controller.ts
@@ -43,10 +43,10 @@ export class PmsJtbConnectController {
           throw new HttpException(e.response?.data, e.response?.status);
         }
         else if (e.request) {
-          this.logger.log(`error.request = ${e.request}`);
-          throw new HttpException(e.request, e.status);
+          this.logger.log(`error.message = ${e.message}`);
+          throw new HttpException(e.message, 504);
         }
-        throw new HttpException(e.message, e.status);
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -80,10 +80,10 @@ export class PmsJtbConnectController {
           throw new HttpException(e.response?.data, e.response?.status);
         }
         else if (e.request) {
-          this.logger.log(`error.request = ${e.request}`);
-          throw new HttpException(e.request, e.status);
+          this.logger.log(`error.message = ${e.message}`);
+          throw new HttpException(e.message, 504);
         }
-        throw new HttpException(e.message, e.status);
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -114,10 +114,10 @@ export class PmsJtbConnectController {
           throw new HttpException(e.response?.data, e.response?.status);
         }
         else if (e.request) {
-          this.logger.log(`error.request = ${e.request}`);
-          throw new HttpException(e.request, e.status);
+          this.logger.log(`error.message = ${e.message}`);
+          throw new HttpException(e.message, 504);
         }
-        throw new HttpException(e.message, e.status);
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -148,10 +148,10 @@ export class PmsJtbConnectController {
           throw new HttpException(e.response?.data, e.response?.status);
         }
         else if (e.request) {
-          this.logger.log(`error.request = ${e.request}`);
-          throw new HttpException(e.request, e.status);
+          this.logger.log(`error.message = ${e.message}`);
+          throw new HttpException(e.message, 504);
         }
-        throw new HttpException(e.message, e.status);
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,13 +2,13 @@ timeout: 1800s
 steps:
 
   - id: 'Install: backend'
-    name: node:18
+    name: node:22
     dir: './backend'
     entrypoint: npm
     args: ['install']
 
   - id: 'Build: backend'
-    name: node:18
+    name: node:22
     dir: './backend'
     entrypoint: npm
     args: ['run', 'build:prod']
@@ -36,7 +36,7 @@ steps:
       - deploy
       - ${_FUNCTION_NAME}
       - --entry-point=api
-      - --runtime=nodejs18
+      - --runtime=nodejs22
       - --region=${_FUNCTION_REGION}
       - --source=.
       - --trigger-http


### PR DESCRIPTION
## 概要
本番アラート `[production]PMS連携エラー`（claim2 / status=500）の対応。ステージングで検証済み（#39, #40）。

## 変更内容

### 1. jtbConnectプロキシのネットワークエラー処理修正（84396c3）
JTB DCH からの応答がないネットワークエラー（`read ECONNRESET` 等）の際、`catchError` の `e.request` 分岐がシリアライズ不能な生の `ClientRequest` オブジェクトと `undefined` ステータスで `HttpException` を throw し、`TypeError: Converting circular structure to JSON` で関数がクラッシュ → 原因不明の 500 を返していた。

- `e.request` 分岐: エラーメッセージ文字列 + **504** を返す（JTB接続断として観測可能に）
- 最終フォールバック: `e.status ?? 500` で undefined ステータスを排除
- GET/POST/PUT/DELETE 4メソッドすべてに適用

### 2. GCFランタイム nodejs18 → nodejs22（8fe38ed）
nodejs18 が GCF 1st gen でサポート終了しデプロイ不能だったため、1st gen で GA の nodejs22 へ更新（nodejs20 は DEPRECATED）。

- `cloudbuild.yaml`: `--runtime=nodejs22`、ビルドイメージ `node:22`
- `backend/package.json` / lock: engines `22`

## 検証
- node:22 コンテナで Cloud Build 同一手順（npm install → nest build）成功、ビルド成果物のロード確認済み
- ステージングデプロイ成功（runtime=nodejs22 / ACTIVE）
- デプロイ後、毎時のJTB同期バッチ3回すべて正常（reservelist 201応答、エラー・クラッシュゼロ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)