### PR TITLE
DMS-1049/DMS-1050: プロキシの認証ヘッダーログ露出とネットワークエラー処理を修正

### DIFF
--- a/backend/src/baycom.controller.ts
+++ b/backend/src/baycom.controller.ts
@@ -1,13 +1,16 @@
-import { Controller, HttpException, Request, Get, Post, Put, Delete, Req, Param, Query } from '@nestjs/common';
+import { Controller, HttpException, Request, Get, Post, Put, Delete, Req, Param, Query, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios'
 import { AppService } from './app.service';
 import { catchError, map } from 'rxjs';
+import { formatErrorForLog } from './utils/logSanitizer';
 const qs = require('qs');
 
 const baseUrl = 'https://api.connected-platform.com/v1/';
 
 @Controller('baycom')
 export class BaycomController {
+  private logger: Logger = new Logger(BaycomController.name);
+
   constructor(
     private readonly httpService: HttpService,
   ) {}
@@ -29,7 +32,14 @@ export class BaycomController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        throw new HttpException(e.response.data, e.response.status);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
+        if (e.response) {
+          throw new HttpException(e.response.data, e.response.status);
+        }
+        else if (e.request) {
+          throw new HttpException(e.message, 504);
+        }
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -52,7 +62,14 @@ export class BaycomController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        throw new HttpException(e.response.data, e.response.status);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
+        if (e.response) {
+          throw new HttpException(e.response.data, e.response.status);
+        }
+        else if (e.request) {
+          throw new HttpException(e.message, 504);
+        }
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -75,7 +92,14 @@ export class BaycomController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        throw new HttpException(e.response.data, e.response.status);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
+        if (e.response) {
+          throw new HttpException(e.response.data, e.response.status);
+        }
+        else if (e.request) {
+          throw new HttpException(e.message, 504);
+        }
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -98,7 +122,14 @@ export class BaycomController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        throw new HttpException(e.response.data, e.response.status);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
+        if (e.response) {
+          throw new HttpException(e.response.data, e.response.status);
+        }
+        else if (e.request) {
+          throw new HttpException(e.message, 504);
+        }
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }

--- a/backend/src/jtbConnect.controller.ts
+++ b/backend/src/jtbConnect.controller.ts
@@ -2,6 +2,7 @@ import { Controller, HttpException, Request, Get, Post, Put, Delete, Req, Param,
 import { HttpService } from '@nestjs/axios'
 import { AppService } from './app.service';
 import { catchError, map } from 'rxjs';
+import { maskHeadersForLog, formatErrorForLog } from './utils/logSanitizer';
 const qs = require('qs');
 
 const HOST_PATH = {
@@ -37,7 +38,7 @@ export class PmsJtbConnectController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        this.logger.log(`error = ${JSON.stringify(e.toJSON())}`);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
         if (e.response) {
           this.logger.log(`error.response.data = ${JSON.stringify(e.response?.data)}`);
           throw new HttpException(e.response?.data, e.response?.status);
@@ -68,13 +69,13 @@ export class PmsJtbConnectController {
     };
     this.logger.log(`baseUrl = ${baseUrl}`);
     this.logger.log(`url = ${url}`);
-    this.logger.log(`requestHeaders = ${JSON.stringify(requestHeaders)}`);
+    this.logger.log(`requestHeaders = ${JSON.stringify(maskHeadersForLog(requestHeaders))}`);
     return this.httpService.post(url, requestBody, {
       headers: requestHeaders
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        this.logger.log(`error = ${JSON.stringify(e.toJSON())}`);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
         if (e.response) {
           this.logger.log(`error.response.data = ${JSON.stringify(e.response?.data)}`);
           throw new HttpException(e.response?.data, e.response?.status);
@@ -108,7 +109,7 @@ export class PmsJtbConnectController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        this.logger.log(`error = ${JSON.stringify(e.toJSON())}`);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
         if (e.response) {
           this.logger.log(`error.response.data = ${JSON.stringify(e.response?.data)}`);
           throw new HttpException(e.response?.data, e.response?.status);
@@ -142,7 +143,7 @@ export class PmsJtbConnectController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        this.logger.log(`error = ${JSON.stringify(e.toJSON())}`);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
         if (e.response) {
           this.logger.log(`error.response.data = ${JSON.stringify(e.response?.data)}`);
           throw new HttpException(e.response?.data, e.response?.status);

--- a/backend/src/keyvox.controller.ts
+++ b/backend/src/keyvox.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, HttpException, Request, Get, Post, Put, Delete, Req, Param, Query, Logger, InternalServerErrorException } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios'
 import { catchError, map } from 'rxjs';
+import { maskHeadersForLog, formatErrorForLog } from './utils/logSanitizer';
 const qs = require('qs');
 
 const baseUrl = 'https://eco.blockchainlock.io/api/eagle-pms/v1/';
@@ -26,7 +27,7 @@ export class KeyvoxController {
       delete requestHeaders.host
     }
     this.logger.log(`url = ${url}`);
-    this.logger.log(`headers = ${JSON.stringify(requestHeaders)}`);
+    this.logger.log(`headers = ${JSON.stringify(maskHeadersForLog(requestHeaders))}`);
     return this.httpService.get(url, {
       headers: requestHeaders
     }).pipe(
@@ -50,7 +51,7 @@ export class KeyvoxController {
     }
     this.logger.log(`url = ${url}`);
     this.logger.log(`body = ${JSON.stringify(requestBody)}`);
-    this.logger.log(`headers = ${JSON.stringify(requestHeaders)}`);
+    this.logger.log(`headers = ${JSON.stringify(maskHeadersForLog(requestHeaders))}`);
     return this.httpService.post(url, requestBody, {
       headers: requestHeaders
     }).pipe(
@@ -74,7 +75,7 @@ export class KeyvoxController {
     }
     this.logger.log(`url = ${url}`);
     this.logger.log(`body = ${JSON.stringify(requestBody)}`);
-    this.logger.log(`headers = ${JSON.stringify(requestHeaders)}`);
+    this.logger.log(`headers = ${JSON.stringify(maskHeadersForLog(requestHeaders))}`);
     return this.httpService.put(url, requestBody, {
       headers: requestHeaders
     }).pipe(
@@ -98,7 +99,7 @@ export class KeyvoxController {
     }
     this.logger.log(`url = ${url}`);
     this.logger.log(`body = ${JSON.stringify(requestBody)}`);
-    this.logger.log(`headers = ${JSON.stringify(requestHeaders)}`);
+    this.logger.log(`headers = ${JSON.stringify(maskHeadersForLog(requestHeaders))}`);
     return this.httpService.delete(url, {
       headers: requestHeaders
     }).pipe(
@@ -108,10 +109,11 @@ export class KeyvoxController {
   }
 
   private async errorHandler(error: any) {
-    this.logger.log(`error = ${error}`);
+    this.logger.log(`error = ${formatErrorForLog(error)}`);
     if (error.response) {
       throw new HttpException(error.response.data, error.response.status);
     }
-    throw new InternalServerErrorException(error);
+    // errorオブジェクトをそのまま渡すとtoJSON()経由でconfig.headers(認証ヘッダー含む)がレスポンスに載る
+    throw new InternalServerErrorException(error.message);
   }
 }

--- a/backend/src/payPay.controller.ts
+++ b/backend/src/payPay.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, HttpException, Request, Get, Post, Put, Delete, Req, Param, Query, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios'
 import { catchError, map } from 'rxjs';
+import { maskHeadersForLog } from './utils/logSanitizer';
 const qs = require('qs');
 
 const HOST_PATH = {
@@ -34,7 +35,7 @@ export class PaymentByPayPayController {
     };
     this.logger.log(`baseUrl = ${baseUrl}`);
     this.logger.log(`url = ${url}`);
-    this.logger.log(`requestHeaders = ${JSON.stringify(requestHeaders)}`);
+    this.logger.log(`requestHeaders = ${JSON.stringify(maskHeadersForLog(requestHeaders))}`);
     return this.httpService.get(url, {
       headers: requestHeaders
     }).pipe(
@@ -63,7 +64,7 @@ export class PaymentByPayPayController {
     };
     this.logger.log(`baseUrl = ${baseUrl}`);
     this.logger.log(`url = ${url}`);
-    this.logger.log(`requestHeaders = ${JSON.stringify(requestHeaders)}`);
+    this.logger.log(`requestHeaders = ${JSON.stringify(maskHeadersForLog(requestHeaders))}`);
     this.logger.log(`requestBody = ${JSON.stringify(requestBody)}`);
     return this.httpService.post(url, requestBody, {
       headers: requestHeaders
@@ -93,7 +94,7 @@ export class PaymentByPayPayController {
     };
     this.logger.log(`baseUrl = ${baseUrl}`);
     this.logger.log(`url = ${url}`);
-    this.logger.log(`requestHeaders = ${JSON.stringify(requestHeaders)}`);
+    this.logger.log(`requestHeaders = ${JSON.stringify(maskHeadersForLog(requestHeaders))}`);
     this.logger.log(`requestBody = ${JSON.stringify(requestBody)}`);
     return this.httpService.put(url, requestBody, {
       headers: requestHeaders
@@ -122,7 +123,7 @@ export class PaymentByPayPayController {
     };
     this.logger.log(`baseUrl = ${baseUrl}`);
     this.logger.log(`url = ${url}`);
-    this.logger.log(`requestHeaders = ${JSON.stringify(requestHeaders)}`);
+    this.logger.log(`requestHeaders = ${JSON.stringify(maskHeadersForLog(requestHeaders))}`);
     return this.httpService.delete(url, {
       headers: requestHeaders
     }).pipe(

--- a/backend/src/payPay.controller.ts
+++ b/backend/src/payPay.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, HttpException, Request, Get, Post, Put, Delete, Req, Param, Query, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios'
 import { catchError, map } from 'rxjs';
-import { maskHeadersForLog } from './utils/logSanitizer';
+import { maskHeadersForLog, formatErrorForLog } from './utils/logSanitizer';
 const qs = require('qs');
 
 const HOST_PATH = {
@@ -41,7 +41,14 @@ export class PaymentByPayPayController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        throw new HttpException(e.response.data, e.response.status);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
+        if (e.response) {
+          throw new HttpException(e.response.data, e.response.status);
+        }
+        else if (e.request) {
+          throw new HttpException(e.message, 504);
+        }
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -71,7 +78,14 @@ export class PaymentByPayPayController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        throw new HttpException(e.response.data, e.response.status);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
+        if (e.response) {
+          throw new HttpException(e.response.data, e.response.status);
+        }
+        else if (e.request) {
+          throw new HttpException(e.message, 504);
+        }
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -101,7 +115,14 @@ export class PaymentByPayPayController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        throw new HttpException(e.response.data, e.response.status);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
+        if (e.response) {
+          throw new HttpException(e.response.data, e.response.status);
+        }
+        else if (e.request) {
+          throw new HttpException(e.message, 504);
+        }
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }
@@ -129,7 +150,14 @@ export class PaymentByPayPayController {
     }).pipe(
       map(response => response.data),
       catchError(e => {
-        throw new HttpException(e.response.data, e.response.status);
+        this.logger.log(`error = ${formatErrorForLog(e)}`);
+        if (e.response) {
+          throw new HttpException(e.response.data, e.response.status);
+        }
+        else if (e.request) {
+          throw new HttpException(e.message, 504);
+        }
+        throw new HttpException(e.message, e.status ?? 500);
       }),
     );
   }

--- a/backend/src/utils/logSanitizer.ts
+++ b/backend/src/utils/logSanitizer.ts
@@ -1,0 +1,29 @@
+// 認証系ヘッダーをログに出さないためのマスク
+const SENSITIVE_HEADER_NAMES = [
+  'authorization',
+  'ocp-apim-subscription-key',
+  'x-assume-merchant',
+  'apikey',
+  'api-key',
+  'x-api-key',
+  'sign',
+  'cookie',
+  'x-auth-token',
+];
+
+export const maskHeadersForLog = (headers: Record<string, any>) => {
+  const masked: Record<string, any> = {};
+  for (const [key, value] of Object.entries(headers ?? {})) {
+    masked[key] = SENSITIVE_HEADER_NAMES.includes(key.toLowerCase()) ? '***MASKED***' : value;
+  }
+  return masked;
+};
+
+// axiosエラーのtoJSON()はconfig.headers(認証ヘッダー含む)を丸ごと含むため使用禁止
+export const formatErrorForLog = (e: any) => JSON.stringify({
+  message: e.message,
+  code: e.code,
+  status: e.response?.status,
+  method: e.config?.method,
+  url: e.config?.url,
+});


### PR DESCRIPTION
## 関連issue

- kujira-system/and-iot-api-nest#1910 (DMS-1049)
- kujira-system/and-iot-api-nest#1911 (DMS-1050)

## DMS-1049: 認証ヘッダーのログ平文露出を修正

`PmsJtbConnectController` がリクエストのたびに `Ocp-Apim-Subscription-Key`（JTB APIサブスクリプションキー）を平文で Cloud Logging に出力していた問題（2026-07-27 本番ログで露出確認）と、他プロキシの同種露出を修正する。

- `src/utils/logSanitizer.ts` を新設
  - `maskHeadersForLog()`: 認証系ヘッダー名（authorization / ocp-apim-subscription-key / x-assume-merchant / apikey / api-key / x-api-key / sign / cookie / x-auth-token、case-insensitive）を `***MASKED***` に置換
  - `formatErrorForLog()`: axiosエラーから message/code/status/method/url のみ抽出（`toJSON()` は config.headers に認証ヘッダーを含むため使用禁止）
- jtbConnect: postApi のヘッダーログをマスク経由に変更し、catchError の `JSON.stringify(e.toJSON())` を全廃。ヘルパーは共通ユーティリティへ切り出し
- payPay: 全4ハンドラの `requestHeaders` ログ（Authorization平文）をマスク経由に変更
- keyvox: 全4ハンドラの `headers` 丸ごとログをマスク経由に変更。あわせて `errorHandler` の `InternalServerErrorException(error)` が axiosエラーの `toJSON()` 経由で `config.headers` を**HTTPレスポンス本文に載せる**問題を `error.message` のみに修正
- baycom: ログ出力自体が存在しないため露出修正は不要

## DMS-1050: payPay/baycom の catchError がネットワークエラーで TypeError になる問題を修正

`e.response.data` の無条件参照により、外部APIへ到達できないエラー（timeout / ECONNREFUSED 等）では `e.response` が undefined で TypeError になっていた。jtbConnect（DMS-1015）と同じ分岐に横展開:

- `e.response` あり → そのまま HttpException で転送
- `e.request` のみ → 504
- それ以外 → `e.status ?? 500`

baycom には Logger を追加し、エラーログは `formatErrorForLog` 経由で出力（認証ヘッダー非含有）。

## 検証

- `backend` で `npx tsc --noEmit` 通過（各コミット時点で確認）

## 残課題（スコープ外）

- 既に本番 Cloud Logging に記録済みのキーはログ保持期間中は閲覧可能。JTBサブスクリプションキー等のローテーションは別途検討（issue #1910 記載）

🤖 Generated with [Claude Code](https://claude.com/claude-code)