### PR TITLE
DMS-1092: PayPay APIエンドポイントを新ドメインへ移行

### DIFF
--- a/backend/src/payPay.controller.ts
+++ b/backend/src/payPay.controller.ts
@@ -4,10 +4,11 @@ import { catchError, map } from 'rxjs';
 import { maskHeadersForLog, formatErrorForLog } from './utils/logSanitizer';
 const qs = require('qs');
 
+// 2026-11-01にPayPay側で旧ドメイン(api.paypay.ne.jp等)が廃止されるため新ドメインへ移行
 const HOST_PATH = {
-  PROD: 'https://api.paypay.ne.jp',
-  STAGING: 'https://stg-api.sandbox.paypay.ne.jp',
-  PERF_MODE: 'https://perf-api.paypay.ne.jp',
+  PROD: 'https://apigw.paypay.ne.jp',
+  STAGING: 'https://apigw.sandbox.paypay.ne.jp',
+  PERF_MODE: 'https://perf-apigw.paypay.ne.jp',
 };
 
 @Controller(`payPay/:environment(PROD|STAGING|PERF_MODE)/`)


### PR DESCRIPTION
## 関連issue

- kujira-system/and-iot-api-nest#2022 (DMS-1092)

## 概要

PayPay側で **2026-11-01** に旧APIドメインが廃止されるため、payPayプロキシの転送先を新ドメインへ移行する。

| 環境 | 旧 | 新 |
|---|---|---|
| PROD | `api.paypay.ne.jp` | `apigw.paypay.ne.jp` |
| STAGING | `stg-api.sandbox.paypay.ne.jp` | `apigw.sandbox.paypay.ne.jp` |
| PERF_MODE | `perf-api.paypay.ne.jp` | `perf-apigw.paypay.ne.jp` |

パスは変更なし（`/v2/codes` 等はそのまま）。対応表は公式SDK `@paypayopa/paypayopa-sdk-node` **2.2.0**（2026-06-15公開）の `lib/environments.js` に準拠。同バージョンの dist 差分はこのホスト定義1ファイルのみ。

## SDK更新では直らない点

PayPay社のFAQは「SDK利用者は最新版へアップデート」と案内しているが、当システムには当てはまらない。

`and-iot-api-nest` の `PayPayApiService` は `CustomConf` で SDK の `hostName` を環境変数 `PAYPAY_SETTING` の値（= 本プロキシのホスト）に上書きしており、SDK内蔵のドメイン定義は使われない。**api-nest の SDK を 2.2.0 に上げても本番の宛先は旧ドメインのまま**で、本PRの変更が必須。逆に本PRを入れれば api-nest 側は SDK・環境変数ともに変更不要。

## 検証

- `npm run build:prod` 成功
- 新ドメインへの疎通確認（未認証プローブ）

  | URL | 応答 |
  |---|---|
  | `https://apigw.paypay.ne.jp/v2/codes/payments/{id}` | 401（旧 `api.paypay.ne.jp` と同一） |
  | `https://apigw.sandbox.paypay.ne.jp/v2/codes/payments/{id}` | 401（旧 `stg-api.sandbox.paypay.ne.jp` と同一） |

  いずれも `x-request-id: OPA...` を返しており、OPAバックエンドへ到達していることを確認。

## マージ後に必要な確認

- ステージング（PayPay sandbox）で実決済フロー：QRコード発行 → 決済 → 決済詳細取得 → 取消/QR削除
- 問題なければ `master` へのPRで本番反映（旧ドメインは2026-11-01まで有効なため、期限前に余裕をもって実施）
