### PR TITLE
DMS-1092: PayPay APIエンドポイントを新ドメインへ移行（本番リリース）

### DIFF
--- a/backend/src/payPay.controller.ts
+++ b/backend/src/payPay.controller.ts
@@ -4,10 +4,11 @@ import { catchError, map } from 'rxjs';
 import { maskHeadersForLog, formatErrorForLog } from './utils/logSanitizer';
 const qs = require('qs');
 
+// 2026-11-01にPayPay側で旧ドメイン(api.paypay.ne.jp等)が廃止されるため新ドメインへ移行
 const HOST_PATH = {
-  PROD: 'https://api.paypay.ne.jp',
-  STAGING: 'https://stg-api.sandbox.paypay.ne.jp',
-  PERF_MODE: 'https://perf-api.paypay.ne.jp',
+  PROD: 'https://apigw.paypay.ne.jp',
+  STAGING: 'https://apigw.sandbox.paypay.ne.jp',
+  PERF_MODE: 'https://perf-apigw.paypay.ne.jp',
 };
 
 @Controller(`payPay/:environment(PROD|STAGING|PERF_MODE)/`)


### PR DESCRIPTION
## 関連issue

- kujira-system/and-iot-api-nest#2022 (DMS-1092)

## 概要

本番リリース。PayPay側で **2026-11-01** に旧APIドメインが廃止されるため、payPayプロキシの転送先を新ドメインへ移行する。

含まれる変更は #43 の1件のみ（`backend/src/payPay.controller.ts` 3行）。

| 環境 | 旧 | 新 |
|---|---|---|
| PROD | `api.paypay.ne.jp` | `apigw.paypay.ne.jp` |
| STAGING | `stg-api.sandbox.paypay.ne.jp` | `apigw.sandbox.paypay.ne.jp` |
| PERF_MODE | `perf-api.paypay.ne.jp` | `perf-apigw.paypay.ne.jp` |

パスは変更なし。対応表は公式SDK `@paypayopa/paypayopa-sdk-node` 2.2.0（2026-06-15公開）の `lib/environments.js` に準拠。

## ステージング検証結果（2026-08-05）

デプロイ後、実決済フローを2件通し、実運用で使われる全エンドポイントが新ドメインで正常動作することを確認した。

| API | 結果 |
|---|---|
| QRCodeCreate (`POST /v2/codes`) | 成功（計4回。うち1回は400エラーの透過確認） |
| QRCodeDelete (`DELETE /v2/codes/{codeId}`) | 成功（計2回） |
| GetCodePaymentDetails (`GET /v2/codes/payments/{id}`) | 成功（ポーリングで決済成立を検知） |
| PaymentCancel (`DELETE /v2/payments/{id}`) | 呼び出し導線が存在しない未使用エンドポイントのため対象外 |

- 決済成立2件がDBまで到達（`paymentStatus:true` / `paymentTypeAtCheckedIn:"PayPay"`）
- Cloud Functions 側の ERROR は 0件
- CloudFront 経由になったことによるレイテンシ悪化なし（QR発行 68〜540ms）
- 検証中に出た `DUPLICATE_DYNAMIC_QR_REQUEST` は本移行と無関係の既存仕様（`merchantPaymentId = bookingId` 固定のため、QR有効期限5分以内の再発行は必ず衝突し、front側が削除→再発行でリカバリする設計）

## マージ後の動作

Cloud Build トリガー `Cloud-Functions`（`^master$`）が発火し、本番の Cloud Functions `and-iot-cloud-functions`（プロジェクト `and-iot-api`）が更新される。

デプロイ完了後、プロキシ経由の未認証プローブと Cloud Logging で転送先が `https://apigw.paypay.ne.jp` になっていることを確認する。
